### PR TITLE
ipq807x: add "512m memory profile" dts patch

### DIFF
--- a/feeds.conf.default
+++ b/feeds.conf.default
@@ -2,7 +2,7 @@ src-git packages https://github.com/immortalwrt/packages.git
 src-git luci https://github.com/immortalwrt/luci.git
 src-git routing https://github.com/openwrt-routing/packages.git
 src-git telephony https://github.com/openwrt/telephony.git
-src-git nss_packages https://github.com/robimarko/nss-packages.git
+src-git nss_packages https://github.com/1715173329/nss-packages.git;nss-crypto
 #src-git video https://github.com/openwrt/video.git
 #src-git targets https://github.com/openwrt/targets.git
 #src-git oldpackages http://git.openwrt.org/packages.git

--- a/package/kernel/mac80211/ath.mk
+++ b/package/kernel/mac80211/ath.mk
@@ -54,6 +54,7 @@ config-$(CONFIG_ATH9K_TX99) += ATH9K_TX99
 config-$(CONFIG_ATH9K_UBNTHSR) += ATH9K_UBNTHSR
 config-$(CONFIG_ATH10K_LEDS) += ATH10K_LEDS
 config-$(CONFIG_ATH10K_THERMAL) += ATH10K_THERMAL
+config-$(CONFIG_ATH11K_MEM_PROFILE_512M) += ATH11K_MEM_PROFILE_512M
 
 config-$(call config_package,ath9k-htc) += ATH9K_HTC
 config-$(call config_package,ath10k) += ATH10K ATH10K_PCI
@@ -308,6 +309,10 @@ define KernelPackage/ath11k/config
                bool "Enable thermal sensors and throttling support"
                depends on PACKAGE_kmod-ath11k
                default y if TARGET_ipq807x
+
+       config ATH11K_MEM_PROFILE_512M
+               bool "Enable 512MB profile"
+               depends on PACKAGE_kmod-ath11k
 
 endef
 

--- a/package/kernel/mac80211/patches/ath11k/133-ath11k-fix-for-peer-memory-corruption.patch
+++ b/package/kernel/mac80211/patches/ath11k/133-ath11k-fix-for-peer-memory-corruption.patch
@@ -1,0 +1,103 @@
+--- a/drivers/net/wireless/ath/ath11k/dp_rx.c
++++ b/drivers/net/wireless/ath/ath11k/dp_rx.c
+@@ -1492,11 +1492,9 @@ struct htt_ppdu_stats_info *ath11k_dp_ht
+ {
+ 	struct htt_ppdu_stats_info *ppdu_info;
+ 
+-	spin_lock_bh(&ar->data_lock);
+ 	if (!list_empty(&ar->ppdu_stats_info)) {
+ 		list_for_each_entry(ppdu_info, &ar->ppdu_stats_info, list) {
+ 			if (ppdu_info->ppdu_id == ppdu_id) {
+-				spin_unlock_bh(&ar->data_lock);
+ 				return ppdu_info;
+ 			}
+ 		}
+@@ -1510,16 +1508,13 @@ struct htt_ppdu_stats_info *ath11k_dp_ht
+ 			kfree(ppdu_info);
+ 		}
+ 	}
+-	spin_unlock_bh(&ar->data_lock);
+ 
+ 	ppdu_info = kzalloc(sizeof(*ppdu_info), GFP_ATOMIC);
+ 	if (!ppdu_info)
+ 		return NULL;
+ 
+-	spin_lock_bh(&ar->data_lock);
+ 	list_add_tail(&ppdu_info->list, &ar->ppdu_stats_info);
+ 	ar->ppdu_stat_list_depth++;
+-	spin_unlock_bh(&ar->data_lock);
+ 
+ 	return ppdu_info;
+ }
+@@ -1549,8 +1544,10 @@ static int ath11k_htt_pull_ppdu_stats(st
+ 	if (ath11k_debugfs_is_pktlog_lite_mode_enabled(ar))
+ 		trace_ath11k_htt_ppdu_stats(ar, skb->data, len);
+ 
++	spin_lock_bh(&ar->data_lock);
+ 	ppdu_info = ath11k_dp_htt_get_ppdu_desc(ar, ppdu_id);
+ 	if (!ppdu_info) {
++		spin_unlock_bh(&ar->data_lock);
+ 		ret = -EINVAL;
+ 		goto exit;
+ 	}
+@@ -1560,10 +1557,12 @@ static int ath11k_htt_pull_ppdu_stats(st
+ 				     ath11k_htt_tlv_ppdu_stats_parse,
+ 				     (void *)ppdu_info);
+ 	if (ret) {
++		spin_unlock_bh(&ar->data_lock);
+ 		ath11k_warn(ab, "Failed to parse tlv %d\n", ret);
+ 		goto exit;
+ 	}
+ 
++	spin_unlock_bh(&ar->data_lock);
+ exit:
+ 	rcu_read_unlock();
+ 
+--- a/drivers/net/wireless/ath/ath11k/mac.c
++++ b/drivers/net/wireless/ath/ath11k/mac.c
+@@ -2451,22 +2451,28 @@ static int ath11k_clear_peer_keys(struct
+ 	int ret;
+ 	int i;
+ 	u32 flags = 0;
++	struct ieee80211_key_conf *keys[WMI_MAX_KEY_INDEX + 1];
+ 
+ 	lockdep_assert_held(&ar->conf_mutex);
+ 
+ 	spin_lock_bh(&ab->base_lock);
+ 	peer = ath11k_peer_find(ab, arvif->vdev_id, addr);
+-	spin_unlock_bh(&ab->base_lock);
+-
+-	if (!peer)
++	if (!peer) {
++		spin_unlock_bh(&ab->base_lock);
+ 		return -ENOENT;
++	}
++	for (i = 0; i < ARRAY_SIZE(keys); i++) {
++		keys[i]= peer->keys[i];
++		peer->keys[i]= NULL;
++	}
++	spin_unlock_bh(&ab->base_lock);
+ 
+-	for (i = 0; i < ARRAY_SIZE(peer->keys); i++) {
+-		if (!peer->keys[i])
++	for (i = 0; i < ARRAY_SIZE(keys); i++) {
++		if (!keys[i])
+ 			continue;
+ 
+ 		/* key flags are not required to delete the key */
+-		ret = ath11k_install_key(arvif, peer->keys[i],
++		ret = ath11k_install_key(arvif, keys[i],
+ 					 DISABLE_KEY, addr, flags);
+ 		if (ret < 0 && first_errno == 0)
+ 			first_errno = ret;
+@@ -2474,10 +2480,6 @@ static int ath11k_clear_peer_keys(struct
+ 		if (ret < 0)
+ 			ath11k_warn(ab, "failed to remove peer key %d: %d\n",
+ 				    i, ret);
+-
+-		spin_lock_bh(&ab->base_lock);
+-		peer->keys[i] = NULL;
+-		spin_unlock_bh(&ab->base_lock);
+ 	}
+ 
+ 	return first_errno;

--- a/package/kernel/mac80211/patches/ath11k/200-ath11k-use-MHI-provided-APIs-to-allocate-and-free-MHI-controller.patch
+++ b/package/kernel/mac80211/patches/ath11k/200-ath11k-use-MHI-provided-APIs-to-allocate-and-free-MHI-controller.patch
@@ -1,0 +1,39 @@
+diff --git a/drivers/net/wireless/ath/ath11k/mhi.c b/drivers/net/wireless/ath/ath11k/mhi.c
+index aded9a7..1c9d9dc 100644
+--- a/drivers/net/wireless/ath/ath11k/mhi.c
++++ b/drivers/net/wireless/ath/ath11k/mhi.c
+@@ -218,7 +218,7 @@ int ath11k_mhi_register(struct ath11k_pci *ab_pci)
+ 	struct mhi_controller *mhi_ctrl;
+ 	int ret;
+ 
+-	mhi_ctrl = kzalloc(sizeof(*mhi_ctrl), GFP_KERNEL);
++	mhi_ctrl = mhi_alloc_controller();
+ 	if (!mhi_ctrl)
+ 		return -ENOMEM;
+ 
+@@ -234,7 +234,7 @@ int ath11k_mhi_register(struct ath11k_pci *ab_pci)
+ 	ret = ath11k_mhi_get_msi(ab_pci);
+ 	if (ret) {
+ 		ath11k_err(ab, "failed to get msi for mhi\n");
+-		kfree(mhi_ctrl);
++		mhi_free_controller(mhi_ctrl);
+ 		return ret;
+ 	}
+ 
+@@ -252,7 +252,7 @@ int ath11k_mhi_register(struct ath11k_pci *ab_pci)
+ 	ret = mhi_register_controller(mhi_ctrl, &ath11k_mhi_config);
+ 	if (ret) {
+ 		ath11k_err(ab, "failed to register to mhi bus, err = %d\n", ret);
+-		kfree(mhi_ctrl);
++		mhi_free_controller(mhi_ctrl);
+ 		return ret;
+ 	}
+ 
+@@ -265,6 +265,7 @@ void ath11k_mhi_unregister(struct ath11k_pci *ab_pci)
+ 
+ 	mhi_unregister_controller(mhi_ctrl);
+ 	kfree(mhi_ctrl->irq);
++	mhi_free_controller(mhi_ctrl);
+ }
+ 
+ static char *ath11k_mhi_state_to_str(enum ath11k_mhi_state mhi_state)

--- a/package/kernel/mac80211/patches/ath11k/207-ath11k-Enable-512MB-profile-in-ath11k.patch
+++ b/package/kernel/mac80211/patches/ath11k/207-ath11k-Enable-512MB-profile-in-ath11k.patch
@@ -1,0 +1,189 @@
+From 1b402e444ff99efe84d09a084b96c39826783a8e Mon Sep 17 00:00:00 2001
+From: Ramya Gnanasekar <rgnanase@codeaurora.org>
+Date: Thu, 10 Sep 2020 13:33:55 +0530
+Subject: [PATCH] ath11k: Enable 512MB profile in ath11k
+
+Below changes are made to enable 512MB mem mode in ath11k
+        * Makefile changes to implement compilation flag when
+                512MB mem profile is configured.
+        * Enabling 512MB mem profile by default from Makefile
+                for IPQ5018. This can be removed later once
+                512MB profile config is supported.
+        * Update target_mem_mode, number of stations, peer and vap
+                during compile time
+
+Signed-off-by: Ramya Gnanasekar <rgnanase@codeaurora.org>
+---
+ drivers/net/wireless/ath/ath11k/Kconfig |  7 +++++++
+ drivers/net/wireless/ath/ath11k/hw.h    | 14 +++++++++++---
+ drivers/net/wireless/ath/ath11k/qmi.c   |  2 +-
+ drivers/net/wireless/ath/ath11k/qmi.h   |  6 +++++-
+ 4 files changed, 24 insertions(+), 5 deletions(-)
+
+--- a/drivers/net/wireless/ath/ath11k/Kconfig
++++ b/drivers/net/wireless/ath/ath11k/Kconfig
+@@ -60,3 +60,10 @@ config ATH11K_SPECTRAL
+ 	  Enable ath11k spectral scan support
+ 
+ 	  Say Y to enable access to the FFT/spectral data via debugfs.
++
++config ATH11K_MEM_PROFILE_512M
++	bool "ath11k enable 512MB memory profile"
++	depends on ATH11K
++	default n
++	---help---
++	Enables 512MB memory profile for ath11k
+--- a/drivers/net/wireless/ath/ath11k/hw.h
++++ b/drivers/net/wireless/ath/ath11k/hw.h
+@@ -9,11 +9,30 @@
+ #include "wmi.h"
+ 
+ /* Target configuration defines */
++#ifdef CPTCFG_ATH11K_MEM_PROFILE_512M
+ 
++#define TARGET_NUM_VDEVS	8
++#define TARGET_NUM_PEERS_PDEV	(128 + TARGET_NUM_VDEVS)
++/* Max num of stations (per radio) */
++#define TARGET_NUM_STATIONS	128
++#define ATH11K_QMI_TARGET_MEM_MODE	ATH11K_QMI_TARGET_MEM_MODE_512M
++#define ATH11K_DP_TX_COMP_RING_SIZE	8192
++#define ATH11K_DP_RXDMA_MON_STATUS_RING_SIZE	512
++#define ATH11K_DP_RXDMA_MONITOR_BUF_RING_SIZE	128
++#define ATH11K_DP_RXDMA_MONITOR_DST_RING_SIZE	128
++#else
+ /* Num VDEVS per radio */
+ #define TARGET_NUM_VDEVS	(16 + 1)
+ 
+ #define TARGET_NUM_PEERS_PDEV	(512 + TARGET_NUM_VDEVS)
++/* Max num of stations (per radio) */
++#define TARGET_NUM_STATIONS	512
++#define ATH11K_QMI_TARGET_MEM_MODE	ATH11K_QMI_TARGET_MEM_MODE_DEFAULT
++#define ATH11K_DP_TX_COMP_RING_SIZE	32768
++#define ATH11K_DP_RXDMA_MON_STATUS_RING_SIZE	1024
++#define ATH11K_DP_RXDMA_MONITOR_BUF_RING_SIZE	4096
++#define ATH11K_DP_RXDMA_MONITOR_DST_RING_SIZE	2048
++#endif
+ 
+ /* Num of peers for Single Radio mode */
+ #define TARGET_NUM_PEERS_SINGLE		(TARGET_NUM_PEERS_PDEV)
+@@ -24,9 +43,6 @@
+ /* Num of peers for DBS_SBS */
+ #define TARGET_NUM_PEERS_DBS_SBS	(3 * TARGET_NUM_PEERS_PDEV)
+ 
+-/* Max num of stations (per radio) */
+-#define TARGET_NUM_STATIONS	512
+-
+ #define TARGET_NUM_PEERS(x)	TARGET_NUM_PEERS_##x
+ #define TARGET_NUM_PEER_KEYS	2
+ #define TARGET_NUM_TIDS(x)	(2 * TARGET_NUM_PEERS(x) + \
+--- a/drivers/net/wireless/ath/ath11k/qmi.c
++++ b/drivers/net/wireless/ath/ath11k/qmi.c
+@@ -2675,7 +2675,7 @@ int ath11k_qmi_init_service(struct ath11
+ 	memset(&ab->qmi.target_mem, 0, sizeof(struct target_mem_chunk));
+ 	ab->qmi.ab = ab;
+ 
+-	ab->qmi.target_mem_mode = ATH11K_QMI_TARGET_MEM_MODE_DEFAULT;
++	ab->qmi.target_mem_mode = ATH11K_QMI_TARGET_MEM_MODE;
+ 	ret = qmi_handle_init(&ab->qmi.handle, ATH11K_QMI_RESP_LEN_MAX,
+ 			      &ath11k_qmi_ops, ath11k_qmi_msg_handlers);
+ 	if (ret < 0) {
+--- a/drivers/net/wireless/ath/ath11k/qmi.h
++++ b/drivers/net/wireless/ath/ath11k/qmi.h
+@@ -33,10 +33,14 @@
+ 
+ #define QMI_WLANFW_MAX_DATA_SIZE_V01		6144
+ #define ATH11K_FIRMWARE_MODE_OFF		4
+-#define ATH11K_QMI_TARGET_MEM_MODE_DEFAULT	0
+ 
+ struct ath11k_base;
+ 
++enum ath11k_target_mem_mode {
++	ATH11K_QMI_TARGET_MEM_MODE_DEFAULT = 0,
++	ATH11K_QMI_TARGET_MEM_MODE_512M,
++};
++
+ enum ath11k_qmi_file_type {
+ 	ATH11K_QMI_FILE_TYPE_BDF_GOLDEN,
+ 	ATH11K_QMI_FILE_TYPE_CALDATA,
+--- a/local-symbols
++++ b/local-symbols
+@@ -153,6 +153,7 @@ WCN36XX_DEBUGFS=
+ ATH11K=
+ ATH11K_AHB=
+ ATH11K_PCI=
++ATH11K_MEM_PROFILE_512M=
+ ATH11K_DEBUG=
+ ATH11K_DEBUGFS=
+ ATH11K_TRACING=
+--- a/drivers/net/wireless/ath/ath11k/core.h
++++ b/drivers/net/wireless/ath/ath11k/core.h
+@@ -734,6 +734,9 @@ struct ath11k_base {
+ 	u32 num_db_cap;
+ 
+ 	struct timer_list mon_reap_timer;
++
++	atomic_t num_max_allowed;
++
+ 	/* must be last */
+ 	u8 drv_priv[0] __aligned(sizeof(void *));
+ };
+--- a/drivers/net/wireless/ath/ath11k/dp.h
++++ b/drivers/net/wireless/ath/ath11k/dp.h
+@@ -174,8 +174,9 @@ struct ath11k_pdev_dp {
+ 
+ #define DP_WBM_RELEASE_RING_SIZE	64
+ #define DP_TCL_DATA_RING_SIZE		512
+-#define DP_TX_COMP_RING_SIZE		32768
++#define DP_TX_COMP_RING_SIZE		ATH11K_DP_TX_COMP_RING_SIZE
+ #define DP_TX_IDR_SIZE			DP_TX_COMP_RING_SIZE
++#define DP_TX_COMP_MAX_ALLOWED		((DP_TX_COMP_RING_SIZE << 1)/3)
+ #define DP_TCL_CMD_RING_SIZE		32
+ #define DP_TCL_STATUS_RING_SIZE		32
+ #define DP_REO_DST_RING_MAX		4
+@@ -188,9 +189,9 @@ struct ath11k_pdev_dp {
+ #define DP_RXDMA_BUF_RING_SIZE		4096
+ #define DP_RXDMA_REFILL_RING_SIZE	2048
+ #define DP_RXDMA_ERR_DST_RING_SIZE	1024
+-#define DP_RXDMA_MON_STATUS_RING_SIZE	1024
+-#define DP_RXDMA_MONITOR_BUF_RING_SIZE	4096
+-#define DP_RXDMA_MONITOR_DST_RING_SIZE	2048
++#define DP_RXDMA_MON_STATUS_RING_SIZE	ATH11K_DP_RXDMA_MON_STATUS_RING_SIZE
++#define DP_RXDMA_MONITOR_BUF_RING_SIZE	ATH11K_DP_RXDMA_MONITOR_BUF_RING_SIZE
++#define DP_RXDMA_MONITOR_DST_RING_SIZE	ATH11K_DP_RXDMA_MONITOR_BUF_RING_SIZE
+ #define DP_RXDMA_MONITOR_DESC_RING_SIZE	4096
+ 
+ #define DP_RX_BUFFER_SIZE	2048
+--- a/drivers/net/wireless/ath/ath11k/dp_tx.c
++++ b/drivers/net/wireless/ath/ath11k/dp_tx.c
+@@ -262,6 +262,7 @@ tcl_ring_sel:
+ 			skb->data, skb->len);
+ 
+ 	atomic_inc(&ar->dp.num_tx_pending);
++	atomic_inc(&ab->num_max_allowed);
+ 
+ 	return 0;
+ 
+@@ -308,6 +309,7 @@ static void ath11k_dp_tx_free_txbuf(stru
+ 	ar = ab->pdevs[mac_id].ar;
+ 	if (atomic_dec_and_test(&ar->dp.num_tx_pending))
+ 		wake_up(&ar->dp.tx_empty_waitq);
++	atomic_dec(&ab->num_max_allowed);
+ }
+ 
+ static void
+@@ -339,6 +341,7 @@ ath11k_dp_tx_htt_tx_complete_buf(struct
+ 
+ 	if (atomic_dec_and_test(&ar->dp.num_tx_pending))
+ 		wake_up(&ar->dp.tx_empty_waitq);
++	atomic_dec(&ab->num_max_allowed);
+ 
+ 	dma_unmap_single(ab->dev, skb_cb->paddr, msdu->len, DMA_TO_DEVICE);
+ 
+@@ -600,6 +603,7 @@ void ath11k_dp_tx_completion_handler(str
+ 			wake_up(&ar->dp.tx_empty_waitq);
+ 
+ 		ath11k_dp_tx_complete_msdu(ar, msdu, &ts);
++		atomic_dec(&ab->num_max_allowed);
+ 	}
+ }
+ 

--- a/package/kernel/mac80211/patches/ath11k/983-ath11k-Enable-VHT-for-2G.patch
+++ b/package/kernel/mac80211/patches/ath11k/983-ath11k-Enable-VHT-for-2G.patch
@@ -1,0 +1,35 @@
+--- a/drivers/net/wireless/ath/ath11k/mac.c
++++ b/drivers/net/wireless/ath/ath11k/mac.c
+@@ -1593,9 +1593,9 @@ static void ath11k_peer_assoc_h_phymode(
+ 		} else if (sta->vht_cap.vht_supported &&
+ 		    !ath11k_peer_assoc_h_vht_masked(vht_mcs_mask)) {
+ 			if (sta->bandwidth == IEEE80211_STA_RX_BW_40)
+-				phymode = MODE_11AC_VHT40;
++				phymode = MODE_11AC_VHT40_2G;
+ 			else
+-				phymode = MODE_11AC_VHT20;
++				phymode = MODE_11AC_VHT20_2G;
+ 		} else if (sta->ht_cap.ht_supported &&
+ 			   !ath11k_peer_assoc_h_ht_masked(ht_mcs_mask)) {
+ 			if (sta->bandwidth == IEEE80211_STA_RX_BW_40)
+@@ -3552,6 +3552,9 @@ static void ath11k_mac_setup_ht_vht_cap(
+ 			*ht_cap_info = ht_cap;
+ 		band->ht_cap = ath11k_create_ht_cap(ar, ht_cap,
+ 						    rate_cap_rx_chainmask);
++
++		band->vht_cap = ath11k_create_vht_cap(ar, rate_cap_tx_chainmask,
++						      rate_cap_rx_chainmask);
+ 	}
+ 
+ 	if (cap->supported_bands & WMI_HOST_WLAN_5G_CAP && !ar->supports_6ghz) {
+--- a/drivers/net/wireless/ath/ath11k/wmi.c
++++ b/drivers/net/wireless/ath/ath11k/wmi.c
+@@ -346,6 +346,8 @@ ath11k_pull_mac_phy_cap_svc_ready_ext(st
+ 	 * handled.
+ 	 */
+ 	if (mac_phy_caps->supported_bands & WMI_HOST_WLAN_2G_CAP) {
++		pdev_cap->vht_cap = mac_phy_caps->vht_cap_info_2g;
++		pdev_cap->vht_mcs = mac_phy_caps->vht_supp_mcs_2g;
+ 		pdev_cap->tx_chain_mask = mac_phy_caps->tx_chain_mask_2g;
+ 		pdev_cap->rx_chain_mask = mac_phy_caps->rx_chain_mask_2g;
+ 	} else if (mac_phy_caps->supported_bands & WMI_HOST_WLAN_5G_CAP) {

--- a/target/linux/ipq807x/base-files/etc/board.d/01_leds
+++ b/target/linux/ipq807x/base-files/etc/board.d/01_leds
@@ -1,0 +1,18 @@
+
+. /lib/functions/leds.sh
+. /lib/functions/uci-defaults.sh
+
+board=$(board_name)
+
+board_config_update
+
+case $board in
+xiaomi,ax3600|\
+redmi,ax6)
+	ucidef_set_led_netdev "wan" "WAN" "blue:network" "eth0"
+	;;
+esac
+
+board_config_flush
+
+exit 0

--- a/target/linux/ipq807x/files/arch/arm64/boot/dts/qcom/ipq8074-memory-512m.dtsi
+++ b/target/linux/ipq807x/files/arch/arm64/boot/dts/qcom/ipq8074-memory-512m.dtsi
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/* Copyright (C) 2021 AmadeusGhost <amadeus@immortalwrt.org> */
+
+/ {
+	reserved-memory {
+		#address-cells = <2>;
+		#size-cells = <2>;
+		ranges;
+
+		nss@40000000 {
+			no-map;
+			reg = <0x0 0x40000000 0x0 0x01000000>;
+		};
+
+		uboot@4a600000 {
+			no-map;
+			reg = <0x0 0x4a600000 0x0 0x00400000>;
+		};
+
+		sbl@4aa00000 {
+			no-map;
+			reg = <0x0 0x4aa00000 0x0 0x00100000>;
+		};
+
+		smem_region: smem@4ab00000 {
+			no-map;
+			reg = <0x0 0x4ab00000 0x0 0x00100000>;
+		};
+
+		tz@4ac00000 {
+			no-map;
+			reg = <0x0 0x4ac00000 0x0 0x00400000>;
+		};
+
+		q6_region: wcnss@4b000000 {
+			no-map;
+			reg = <0x0 0x4b000000 0x0 0x03700000>;
+		};
+
+		q6_etr_region: q6_etr_dump@4e700000 {
+			no-map;
+			reg = <0x0 0x4e700000 0x0 0x100000>;
+		};
+
+		wifi_dump@50500000 {
+			no-map;
+			reg 	= <0x0 0x50500000 0x0 0x200000>;
+		};
+	};
+};

--- a/target/linux/ipq807x/patches-5.10/161-arm64-dts-ipq8074-512MB-mem-profile.patch
+++ b/target/linux/ipq807x/patches-5.10/161-arm64-dts-ipq8074-512MB-mem-profile.patch
@@ -1,0 +1,33 @@
+--- a/arch/arm64/boot/dts/qcom/ipq8074.dtsi
++++ b/arch/arm64/boot/dts/qcom/ipq8074.dtsi
+@@ -106,7 +106,6 @@
+ 			reg = <0x0 0x4a400000 0x0 0x00200000>;
+ 		};
+ 
+-
+ 		uboot@4a600000 {
+ 			no-map;
+ 			reg = <0x0 0x4a600000 0x0 0x00400000>;
+@@ -129,17 +128,17 @@
+ 
+ 		q6_region: wcnss@4b000000 {
+ 			no-map;
+-			reg = <0x0 0x4b000000 0x0 0x05f00000>;
++			reg = <0x0 0x4b000000 0x0 0x03700000>;
+ 		};
+ 
+-		q6_etr_region: q6_etr_dump@50f00000 {
++		q6_etr_region: q6_etr_dump@4e700000 {
+ 			no-map;
+-			reg = <0x0 0x50f00000 0x0 0x00100000>;
++			reg = <0x0 0x4e700000 0x0 0x00100000>;
+ 		};
+ 
+-		m3_dump@51000000 {
++		m3_dump@4e800000 {
+ 			no-map;
+-			reg = <0x0 0x51000000 0x0 0x100000>;
++			reg = <0x0 0x4e800000 0x0 0x00100000>;
+ 		};
+ 
+ 	};


### PR DESCRIPTION
This patch follows "150-arm64-dts-ipq8074-add-missing-reserved-memory-nodes.patch" and modifies the layout of reserved memory according to "ipq8074-memory-512m.dtsi" with some changes at "wifi_dump" section.

P.S.: This patch is meant for ax3600 and ax6 whose mem is 512MB. It is unclear whether it will work properly on ax9000.